### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,8 @@ indent_size = 2
 
 # Dotnet code style settings:
 [*.{cs,vb}]
+tab_width = 4
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 # Avoid "this." and "Me." if not necessary
@@ -56,6 +58,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:error
 
 # IDE0040: Add accessibility modifiers
 dotnet_diagnostic.IDE0040.severity = error
+
+# IDE1100: Error reading content of source file 'Project.TargetFrameworkMoniker' (i.e. from ThisAssembly)
+dotnet_diagnostic.IDE1100.severity = none
 
 [*.cs]
 # Top-level files are definitely OK

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # normalize by default
 * text=auto encoding=UTF-8
 *.sh text eol=lf
+*.sbn eol=lf
 
 # These are windows specific files which we may as well ensure are
 # always crlf on checkout

--- a/.github/code_of_conduct.md
+++ b/.github/code_of_conduct.md
@@ -1,7 +1,3 @@
 # Code of Conduct
 
-This project has adopted the code of conduct defined by the 
-[Contributor Covenant](https://www.contributor-covenant.org/) to 
-clarify expected behavior in our community.
-
-For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
+Be kind.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,94 @@
+# .NET Repository
+
+**Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
+
+## Working Effectively
+
+### Essential Build Commands
+- **Restore dependencies**: `dotnet restore`
+
+- **Build the entire solution**: `dotnet build`
+
+- **Run tests**: `dnx --yes retest`
+  - Runs all unit tests across the solution
+  - If tests fail due to Azure Storage, run the following commands and retry: `npm install azurite` and `npx azurite &`
+
+### Build Validation and CI Requirements
+- **Always run before committing**: 
+  * `dnx --yes retest`
+  * `dotnet format whitespace -v:diag --exclude ~/.nuget`
+  * `dotnet format style -v:diag --exclude ~/.nuget`
+
+### Project Structure and Navigation
+
+| Directory | Description |
+|-----------|-------------|
+| `src/` | Contains the repo source code. |
+| `bin/` | Contains built packages (if any) |
+
+### Code Style and Formatting
+
+#### EditorConfig Rules
+The repository uses `.editorconfig` at the repo root for consistent code style.
+
+- **Indentation**: 4 spaces for C# files, 2 spaces for XML/YAML/JSON
+- **Line endings**: LF (Unix-style)
+- **Sort using directives**: System.* namespaces first (`dotnet_sort_system_directives_first = true`)
+- **Type references**: Prefer language keywords over framework type names (`int` vs `Int32`)
+- **Modern C# features**: Use object/collection initializers, coalesce expressions when possible, use var when the type is apparent from the right-hand side of the assignment
+- **Visibility modifiers**: only explicitly specify visibility when different from the default (e.g. `public` for classes, no `internal` for classes or `private` for fields, etc.)
+
+#### Formatting Validation
+- CI enforces formatting with `dotnet format whitespace` and `dotnet format style`
+- Run locally: `dotnet format whitespace --verify-no-changes -v:diag --exclude ~/.nuget`
+- Fix formatting: `dotnet format` (without `--verify-no-changes`)
+
+### Testing Practices
+
+#### Test Framework
+- **xUnit** for all unit and integration tests
+- **Moq** for mocking dependencies
+- Located in `src/*.Tests/`
+
+#### Test Attributes
+Custom xUnit attributes are sometimes used for conditional test execution:
+- `[SecretsFact("XAI_API_KEY")]` - Skips test if required secrets are missing from user secrets or environment variables
+- `[LocalFact("SECRET")]` - Runs only locally (skips in CI), requires specified secrets
+- `[CIFact]` - Runs only in CI environment
+
+### Dependency Management
+
+#### Adding Dependencies
+- Add to appropriate `.csproj` file
+- Run `dotnet restore` to update dependencies
+- Ensure version consistency across projects where applicable
+
+#### CI/CD Pipeline
+- **Build workflow**: `.github/workflows/build.yml` - runs on PR and push to main/rel/feature branches
+- **Publish workflow**: Publishes to Sleet feed when `SLEET_CONNECTION` secret is available
+- **OS matrix**: Configured in `.github/workflows/os-matrix.json` (defaults to ubuntu-latest)
+
+### Special Files and Tools
+
+#### dnx Command
+- **Purpose**: built-in tool for running arbitrary dotnet tools that are published on nuget.org. `--yes` auto-confirms install before run.
+- **Example**: `dnx --yes retest` - runs tests with automatic retry on transient failures (retest being a tool package published at https://www.nuget.org/packages/retest)
+- **In CI**: `dnx --yes retest -- --no-build` (skips build, runs tests only)
+
+#### Directory.Build.rsp
+- MSBuild response file with default build arguments
+- `-nr:false` - disables node reuse
+- `-m:1` - single-threaded build (for stability)
+- `-v:m` - minimal verbosity
+
+#### Code Quality
+- All PRs must pass format validation
+- Tests must pass on all target frameworks
+- Follow existing patterns and conventions in the codebase
+
+## Documenting Work
+
+Project implemention details, design and key decisions should be documented in a top-level AGENTS.md file at the repo root. 
+Keep this file updated whenever you make change significant changes for future reference.
+
+User-facing features and APIs should be documented to highlight (not extensively, as an overview) key project features and capabilities, in the readme.md file at the repo root.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,11 @@ updates:
     Extensions:
       patterns:
         - "Microsoft.Extensions*"
+      exclude-patterns:
+        - "Microsoft.Extensions.AI*"
+    ExtensionsAI:
+      patterns:
+        - "Microsoft.Extensions.AI*"
     Web:
       patterns:
         - "Microsoft.AspNetCore*"
@@ -38,3 +43,6 @@ updates:
     ProtoBuf:
       patterns:
         - "protobuf-*"
+    Spectre:
+      patterns:
+        - "Spectre.Console*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
         - Release
         - Debug
   push:
-    branches: [ main, dev, 'dev/*', 'feature/*', 'rel/*' ]
+    branches: [ main, 'feature/*', 'rel/*' ]
     paths-ignore:
       - changelog.md
       - readme.md
@@ -66,15 +66,14 @@ jobs:
           fetch-depth: 0
 
       - name: ⚙ dotnet
-        uses: ./.github/actions/dotnet
+        uses: devlooped/actions-dotnet-env@v1
 
       - name: 🙏 build
         run: dotnet build -m:1 -bl:build.binlog
 
       - name: 🧪 test
-        run: |
-          dotnet tool update -g dotnet-retest
-          dotnet retest -- --no-build
+        shell: pwsh
+        run: dnx --yes retest -- --no-build
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4
@@ -101,12 +100,7 @@ jobs:
           fetch-depth: 0
 
       - name: ⚙ dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            6.x
-            8.x
-            9.x
+        uses: devlooped/actions-dotnet-env@v1
 
       - name: ✓ ensure format
         run: |

--- a/.github/workflows/dotnet-env.yml
+++ b/.github/workflows/dotnet-env.yml
@@ -1,0 +1,44 @@
+name: dotnet-env
+on:
+  workflow_dispatch:
+  push:
+    branches: 
+      - main
+    paths:
+      - '**/*.*proj'
+
+jobs:
+  which-dotnet:
+    runs-on: ubuntu-latest 
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: 🤖 defaults
+        uses: devlooped/actions-bot@v1
+        with:
+          name: ${{ secrets.BOT_NAME }}
+          email: ${{ secrets.BOT_EMAIL }}
+          gh_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🤘 checkout
+        uses: actions/checkout@v4
+        with: 
+          token: ${{ env.GH_TOKEN }}
+
+      - name: 🤌 dotnet
+        uses: devlooped/actions-which-dotnet@v1
+
+      - name: ✍ pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: main
+          branch: which-dotnet
+          delete-branch: true
+          labels: dependencies
+          title: "⚙ Update dotnet versions"
+          body: "Update dotnet versions"
+          commit-message: "Update dotnet versions"
+          token: ${{ env.GH_TOKEN }}          

--- a/.github/workflows/dotnet-file-core.yml
+++ b/.github/workflows/dotnet-file-core.yml
@@ -47,13 +47,19 @@ jobs:
           # if we don't have at least 100 requests left, wait until reset
           if ($rate.remaining -lt 10) {
               $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
-              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              if ($wait -gt 300) {
+                  echo "Rate limit remaining is $($rate.remaining), reset in $wait seconds (more than 5'). Aborting."
+                  exit 1
+              }
+              echo "Rate limit remaining is $($rate.remaining), waiting $wait seconds to reset"
               sleep $wait
               $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
               echo "Rate limit has reset to $($rate.remaining) requests"
           }
 
       - name: 🔄 sync
+        env:
+          GCM_CREDENTIAL_STORE: cache
         run: |
           dotnet tool update -g dotnet-gcm
           # store credentials in plaintext for linux compat
@@ -63,7 +69,7 @@ jobs:
 
           dotnet tool update -g dotnet-file
           $changelog = "$([System.IO.Path]::GetTempPath())dotnet-file.md"
-          dotnet file sync -c:$changelog
+          dotnet file sync -c:$changelog --init https://github.com/devlooped/oss/blob/main/.netconfig
           if (test-path $changelog) {
             echo 'CHANGES<<EOF' >> $env:GITHUB_ENV
             cat $changelog >> $env:GITHUB_ENV
@@ -79,7 +85,7 @@ jobs:
           validate: false
 
       - name: ✍ pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           base: main
           branch: dotnet-file-sync

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - 'main'
     paths:
-      - '**.md'    
+      - '**.md'
       - '!changelog.md'
+      - 'osmfeula.txt'
 
 jobs:
   includes:
@@ -31,14 +32,33 @@ jobs:
       - name: +Mᐁ includes
         uses: devlooped/actions-includes@v1
 
+      - name: 📝 OSMF EULA
+        shell: pwsh
+        run: |
+          $file = "osmfeula.txt"
+          $props = "src/Directory.Build.props"
+          if (-not (test-path $file) -or -not (test-path $props)) {
+            exit 0
+          }
+
+          $product = dotnet msbuild $props -getproperty:Product
+          if (-not $product) { 
+            write-error 'To use OSMF EULA, ensure the $(Product) property is set in Directory.props'
+            exit 1
+          }
+          
+          ((get-content -raw $file) -replace '\$product\$',$product).trim() | set-content $file
+
       - name: ✍ pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: '**.md'
+          add-paths: |
+            **.md
+            *.txt
           base: main
           branch: markdown-includes
           delete-branch: true
-          labels: docs
+          labels: dependencies
           author: ${{ env.BOT_AUTHOR }}
           committer: ${{ env.BOT_AUTHOR }}
           commit-message: +Mᐁ includes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ env:
   VersionLabel: ${{ github.ref }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   MSBUILDTERMINALLOGGER: auto
-  SLEET_FEED_URL: ${{ vars.SLEET_FEED_URL }}
+  SLEET_FEED_URL: https://api.nuget.org/v3/index.json
       
 jobs:
   publish:
@@ -28,15 +28,14 @@ jobs:
           fetch-depth: 0
 
       - name: ⚙ dotnet
-        uses: ./.github/actions/dotnet
+        uses: devlooped/actions-dotnet-env@v1
 
       - name: 🙏 build
         run: dotnet build -m:1 -bl:build.binlog
 
       - name: 🧪 test
-        run: |
-          dotnet tool update -g dotnet-retest
-          dotnet retest -- --no-build
+        shell: pwsh
+        run: dnx --yes retest -- --no-build
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,7 +49,11 @@ jobs:
           # if we don't have at least 100 requests left, wait until reset
           if ($rate.remaining -lt 100) {
               $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
-              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              if ($wait -gt 300) {
+                  echo "Rate limit remaining is $($rate.remaining), reset in $wait seconds (more than 5'). Aborting."
+                  exit 1
+              }
+              echo "Rate limit remaining is $($rate.remaining), waiting $wait seconds to reset"
               sleep $wait
               $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
               echo "Rate limit has reset to $($rate.remaining) requests"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ BenchmarkDotNet.Artifacts
 .genaiscript
 .idea
 local.settings.json
+.env
+*.local
 
 *.suo
 *.sdf

--- a/.netconfig
+++ b/.netconfig
@@ -24,13 +24,13 @@
 	skip
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	sha = e81ab754b366d52d92bd69b24bef1d5b1c610634
-	etag = 7298c6450967975a8782b5c74f3071e1910fc59686e48f9c9d5cd7c68213cf59
+	sha = a62c45934ac2952f2f5d54d8aea4a7ebc1babaff
+	etag = b5e919b472a52d4b522f86494f0f2c0ba74a6d9601454e20e4cbaf744317ff62
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
-	sha = 5f92a68e302bae675b394ef343114139c075993e
-	etag = 338ba6d92c8d1774363396739c2be4257bfc58026f4b0fe92cb0ae4460e1eff7
+	sha = 4a9aa321c4982b83c185cf8dffed181ff84667d5
+	etag = 09cad18280ed04b67f7f87591e5481510df04d44c3403231b8af885664d8fd58
 	weak
 [file ".github/FUNDING.yml"]
 	url = https://github.com/devlooped/.github/blob/main/.github/FUNDING.yml
@@ -39,13 +39,13 @@
 	weak
 [file ".github/dependabot.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/dependabot.yml
-	sha = 49661dbf0720cde93eb5569be7523b5912351560
-	etag = c147ea2f3431ca0338c315c4a45b56ee233c4d30f8d6ab698d0e1980a257fd6a
+	sha = e733294084fb3e75d517a2e961e87df8faae7dc6
+	etag = 3bf8d9214a15c049ca5cfe80d212a8cbe4753b8a638a9804ef73d34c7def9618
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = 931da830a361d69b419887a0edbb424517ca75fc
-	etag = ea785d08ab67abc57629649b0a418a515dc58248de12668f3616908873f8ecc6
+	sha = 5da103cfbc1c4f9b5f59cfa698d2afbd744a7525
+	etag = 851af098748f7cfa5bc3cfd4cc404a6de930532b59ceb2b3b535282c41226f3a
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
@@ -59,13 +59,13 @@
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = 931da830a361d69b419887a0edbb424517ca75fc
-	etag = 62a13b8b34b1b265cdc045bf7ea001dee7bdc184cba7abfea5fe77283cf419a6
+	sha = 7f5f9ee9f362f7e8f951d618f8f799033550e687
+	etag = c60411d1aa4e98e7f69e2d34cbccb8eb7e387ec11f6f8e78ee8d8b92122d7025
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = e0be248fff1d39133345283b8227372b36574b75
-	etag = c449ec6f76803e1891357ca2b8b4fcb5b2e5deeff8311622fd92ca9fbf1e6575
+	sha = a225b7a9f609f26bcc24e0d84f663387be251a7d
+	etag = 20a8b49d57024abbd85aac5b0020c30e5eb68e0384b2761e93727c8780c4a991
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -74,8 +74,8 @@
 	weak
 [file "_config.yml"]
 	url = https://github.com/devlooped/oss/blob/main/_config.yml
-	sha = fa83a5161ba52bc5d510ce0ba75ee0b1f8d4bc63
-	etag = 9139148f845adf503fd3c3c140eb64421fc476a1f9c027fc50825c0efb05f557
+	sha = 68b409c486842062e0de0e5b11e6fdb7cd12d6e2
+	etag = d608aa0ddaedc2d8a87260f50756e8d8314964ad4671b76bd085bcb458757010
 	weak
 [file "assets/css/style.scss"]
 	url = https://github.com/devlooped/oss/blob/main/assets/css/style.scss
@@ -89,13 +89,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 2fff747a9673b499c99f2da183cdd5263fdc9333
-	etag = 0fccddf04f282fe98122ab2610dc2972c205a521254559bf013655c6271b0017
+	sha = dd13ed3334135c30dcb1e3b2295dc7622de298d9
+	etag = bd05f9f240823c0ac79ddfefe654061550c36f82dd94fa513b82900e92686a5f
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = a8b208093599263b7f2d1fe3854634c588ea5199
-	etag = 19087699f05396205e6b050d999a43b175bd242f6e8fac86f6df936310178b03
+	sha = 083a37bd9307ec820bac6ee3c7384083151d36d8
+	etag = 907682e5632a2ba430357e6e042a4ca33cb8c94a3a215d3091aa03f5958a4877
 	weak
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
@@ -122,23 +122,23 @@
 	weak
 [file ".github/workflows/dotnet-file-core.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file-core.yml
-	sha = af171b7a87382ee665ba6fbaeb5f38a3551e1c23
-	etag = 5ce370f52933ab2a4cd50f2b410e842fc5eab23088db2bf98b6c4d4ccdc9022b
+	sha = 61a602fc61eedbdae235f01e93657a6219ac2427
+	etag = 1de1d7aff26365e25be4abc0c728e10c20df9c4f1adc0cd1f28485c5238883e0
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 85829f2510f335f4a411867f3dbaaa116c3ab3de
-	etag = 086f6b6316cc6ea7089c0dcc6980be519e6ed6e6201e65042ef41b82634ec0ee
+	sha = 06628725a6303bb8c4cf3076a384fc982a91bc0b
+	etag = 478f91d4126230e57cc601382da1ba23f9daa054645b4af89800d8dd862e64fd
 	weak
 [file ".github/workflows/triage.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/triage.yml
-	sha = 33000c0c4ab4eb4e0e142fa54515b811a189d55c
-	etag = 013a47739e348f06891f37c45164478cca149854e6cd5c5158e6f073f852b61a
+	sha = 61a602fc61eedbdae235f01e93657a6219ac2427
+	etag = 152cd3a559c08da14d1da12a5262ba1d2e0ed6bed6d2eabf5bd209b0c35d8a75
 	weak
 [file ".github/code_of_conduct.md"]
 	url = https://github.com/devlooped/.github/blob/main/.github/code_of_conduct.md
-	sha = 4d38bd1a1662e69a131dfe2e860a0a832ea89db4
-	etag = fcc35d9f63ba728070d34229be6f8ca403f4cde03e1da183f95e530bf8c632a0
+	sha = 5f8692d9f0dfa48a909bba4af8636773c47e74e6
+	etag = 5bd8ca15d100cc9f0e509d9dbfe8490e3f3a2550f9c9585e558b524d33393002
 	weak
 [file ".github/contributing.md"]
 	url = https://github.com/devlooped/.github/blob/main/.github/contributing.md
@@ -157,8 +157,8 @@
 	weak
 [file "profile/readme.md"]
 	url = https://github.com/devlooped/.github/blob/main/profile/readme.md
-	sha = e8ece8fce8b22aa649984149b9418ba2739e8c53
-	etag = 5c7b850675daacdc2ff8ec0f364b947cc83369a8f9511c13045c0766b8b0611d
+	sha = 1d31ded2d7eb6261f4e98605a95f1dc02c803c13
+	etag = 10d3d2ee21d09e831591a092ea9c405c69c7a929b2bdc58a90035277a664aeee
 	weak
 [file "sponsorlink.jwt"]
 	url = https://github.com/devlooped/.github/blob/main/sponsorlink.jwt
@@ -172,8 +172,8 @@
 	weak
 [file "sponsorlinkr.md"]
 	url = https://github.com/devlooped/.github/blob/main/sponsorlinkr.md
-	sha = a501ccfa743a3d152f6ab06377f71ab22ef4ed9a
-	etag = efe72da5946abeddf63d0a3063da6ff9c2bc5d13a292ec24ddc2c2e40e0d283f
+	sha = 233691f61aa3b73e717e08ba7b1c776de6c7176f
+	etag = 69f8f56717e739038c92f90a0cafbf51f565f3e58524fd0c07031676bcd927a1
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
@@ -184,4 +184,33 @@
 	url = https://github.com/devlooped/.github/blob/main/.github/ISSUE_TEMPLATE/bug.md
 	sha = 80e81d21c020841dfc8678f218d42ddaffad78db
 	etag = 6ab86c474f24c915681abf4dca6c5becf3a211ab09d11e290385890dadd6f97f
+	weak
+[file "readme.tmp.md"]
+	url = https://github.com/devlooped/oss/blob/main/readme.tmp.md
+	skip
+[file "oss.cs"]
+	url = https://github.com/devlooped/oss/blob/main/oss.cs
+	skip
+[file ".github/actions/dotnet/action.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/actions/dotnet/action.yml
+	skip
+[file ".github/copilot-instructions.md"]
+	url = https://github.com/devlooped/oss/blob/main/.github/copilot-instructions.md
+	sha = e616d89d9537c4b8ccf1c20dd277ab82104167c4
+	etag = 6ee650d118a57494d3545d54718ccaa5257b09d54504e9c21514fe596edd9678
+	weak
+[file ".github/workflows/dotnet-env.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-env.yml
+	sha = 77e83f238196d2723640abef0c7b6f43994f9747
+	etag = fcb9759a96966df40dcd24906fd328ddec05953b7e747a6bb8d0d1e4c3865274
+	weak
+[file "osmf.md"]
+	url = https://github.com/devlooped/.github/blob/main/osmf.md
+	sha = e37fbcc1cb019a5d7be4af4ced96df5183cf3227
+	etag = f4c4597412a91483a93a47604058db6ac7a33bf9e5ddccb4fd9a54134d47b328
+	weak
+[file "osmfeula.txt"]
+	url = https://github.com/devlooped/.github/blob/main/osmfeula.txt
+	sha = 666a2a7c315f72199c418f11482a950fc69a8901
+	etag = 91ea15c07bfd784036c6ca931f5b2df7e9767b8367146d96c79caef09d63899f
 	weak

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 theme: jekyll-theme-slate
 
-exclude: [ 'src/', '*.sln', 'Gemfile*', '*.rsp' ]
+exclude: [ 'src/', '*.sln', '*.slnx', 'Gemfile*', '*.rsp' ]

--- a/osmf.md
+++ b/osmf.md
@@ -1,0 +1,9 @@
+## Open Source Maintenance Fee
+
+To ensure the long-term sustainability of this project, users of this package who generate 
+revenue must pay an [Open Source Maintenance Fee](https://opensourcemaintenancefee.org). 
+While the source code is freely available under the terms of the [License](license.txt), 
+this package and other aspects of the project require [adherence to the Maintenance Fee](osmfeula.txt).
+
+To pay the Maintenance Fee, [become a Sponsor](https://github.com/sponsors/devlooped) at the proper 
+OSMF tier. A single fee covers all of [Devlooped packages](https://www.nuget.org/profiles/Devlooped).

--- a/osmfeula.txt
+++ b/osmfeula.txt
@@ -1,0 +1,63 @@
+End User License Agreement
+
+This Open Source Maintenance Fee Agreement ("Agreement") is a legal agreement
+between you ("User") and Devlooped ("Project") for the use of
+$product$ ("Software"), an open source software project licensed under
+the MIT License ("OSI License"), an OSI-approved open source license.
+Project offers a Binary Release of the Software to Users in exchange for a
+maintenance fee ("Fee"). "Binary Release" refers to pre-compiled executable
+versions of the Software provided by Project. By accessing or using the
+Binary Release, User agrees to be bound by the terms of this Agreement.
+
+1. Applicability
+
+Project agrees to provide User with the Binary Release in exchange for the
+Fees outlined in Section 2, subject to the terms of this Agreement. The Fee
+applies only to Users that generate revenue by the Software.
+Non-revenue-generating use of the Software is exempt from this Fee. In
+addition, Users who pay separate support and/or maintenance fees to the
+maintainers of the Software are exempt from the Fee outlined in this
+Agreement. This distinction ensures that duplicate fees are not imposed,
+promoting fairness and consistency while respecting alternative support
+arrangements.
+
+2. Monthly Fee and Payment Terms
+
+Revenue-generating Users required to pay the Fee shall follow the payment
+terms set forth by the Project. Failure to comply with these terms may result
+in suspending access to the Binary Release. However, this does not restrict
+the User from obtaining or redistributing binaries from other sources or
+self-compiling them.
+
+3. Nature of the Fee
+
+The Fee is not a license fee. The Software's source code is licensed to User
+under the OSI License and remains freely distributable under the terms of the
+OSI License and any applicable open-source licenses.
+
+4. Conflicts with OSI License
+
+To the extent any term of this Agreement conflicts with User's rights
+under the OSI License regarding the Software, the OSI License shall govern.
+This Agreement applies only to the Binary Release and does not limit User's
+ability to access, modify, or distribute the Software's source code or
+self-compiled binaries. User may independently compile binaries from the
+Software's source code without this Agreement, subject to OSI License terms.
+User may redistribute the Binary Release received under this Agreement,
+provided such redistribution complies with the OSI License (e.g., including
+copyright and permission notices). This Agreement imposes no additional
+restrictions on such rights.
+
+5. Disclaimer of Warranty and Limitation of Liability
+
+THE SOFTWARE AND BINARY RELEASE ARE PROVIDED BY THE PROJECT "AS IS" AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE PROJECT OR ITS CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THE SOFTWARE AND BINARY RELEASE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/profile/readme.md
+++ b/profile/readme.md
@@ -1,8 +1,43 @@
-Hello there! This is [@kzu](https://github.com/kzu)'s (sounds like 'kah-zu' rather than 'kzoo' 😉) organization account 
-where I publish projects I think might be useful to others and not just personal experiments. 
+Devlooped is all about accelerating your dev loop through sharper tools.
 
-This is also the organization account you can actually [sponsor](https://github.com/sponsors/devlooped) 
-to support my ongoing opensource work.
+These tools span several domains, such as testing, AI, general-purpose CLI and 
+build tools, application architecture, and more. Some are well established, others 
+niche, some large and some small. 
+
+To support us, rather than per-project licensing (which can become costly 
+or annoying to keep track of), we instead offer the Open Source Maintenance Fee, 
+which covers all current and future libraries and tools from Devlooped. 
+
+If a particular software/package does NOT include the OSMF EULA, then you're not bound by it 
+at all.
+
+<div id="osmf"></div>
+
+## Open Source Maintenance Fee
+
+Open Source Software is free, but maintaining an Open Source Project is expensive. Think about:
+
+* Triage issues
+* Keep build scripts working
+* Update software dependencies
+* Track security reports
+* Produce new releases
+* Tackle spam in the discussion forums and issue trackers
+* Maintain signing certificates
+* And many, many other chores
+
+The [Open Source Maintenance Fee](https://opensourcemaintenancefee.org/) is a simple and sensible way to pay for the time and effort they spend sustaining a project.
+
+We started using this approach to test if it can be a viable mechanism for ongoing sustainability 
+(for example [SmallSharp](https://www.nuget.org/packages/SmallSharp), 
+[Devlooped.WhatsApp](https://www.nuget.org/packages/Devlooped.WhatsApp) and others.
+
+If you're using a project with an [Open Source Maintenance Fee EULA](https://opensourcemaintenancefee.org/maintainers/eulas/)
+and you, your organization, or your project makes money, select the monthly payment tier that applies to the size of your organization. 
+If not, a personal sponsorship of your chosen amount to support @kzu's favorite activity is also welcomed!
+
+> Since the Maintenance Fee is paid via GitHub Sponsors, it automatically covers any <a href="#sponsorlink">SponsorLink</a> sponsoring 
+requirements for projects using it. 
 
 ## Stats
 
@@ -16,17 +51,18 @@ to support my ongoing opensource work.
 [![GitHub followers](https://img.shields.io/github/followers/devlooped?logo=GitHub&label=@devlooped%20followers)](https://github.com/devlooped)
 [![GitHub Org's stars](https://img.shields.io/github/stars/devlooped?logo=GitHub&label=@devlooped%20stars)](https://github.com/devlooped)
 
-Some fancy stats about my favorite hobby (coding on GitHub, of course!):
+Some fancy stats about our favorite activity (coding on GitHub, of course!):
+
 
 <p>
 <picture>
   <source
-    srcset="https://github-readme-stats.vercel.app/api?username=kzu&show_icons=true&locale=en&show=discussions_answered&theme=dark&custom_title=Kzu%20Stats%20In%20A%20Nutshell"
+    srcset="https://github-readme-stats.vercel.app/api?username=kzu&show_icons=true&locale=en&show=discussions_answered&theme=dark&custom_title=Stats%20In%20A%20Nutshell"
     media="(prefers-color-scheme: dark)" />
   <source
-    srcset="https://github-readme-stats.vercel.app/api?username=kzu&show_icons=true&locale=en&show=discussions_answered&custom_title=Kzu%20Stats%20In%20A%20Nutshell"
+    srcset="https://github-readme-stats.vercel.app/api?username=kzu&show_icons=true&locale=en&show=discussions_answered&custom_title=Stats%20In%20A%20Nutshell"
     media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
-  <img align="center" src="https://github-readme-stats.vercel.app/api?username=kzu&show_icons=true&locale=en&show=discussions_answered&custom_title=Kzu%20Stats%20In%20A%20Nutshell" />
+  <img align="center" src="https://github-readme-stats.vercel.app/api?username=kzu&show_icons=true&locale=en&show=discussions_answered&custom_title=Stats%20In%20A%20Nutshell" />
 </picture>
 </p>
 
@@ -49,7 +85,8 @@ Some fancy stats about my favorite hobby (coding on GitHub, of course!):
 I created [SponsorLink](https://www.devlooped.com/SponsorLink/) as a mechanism to remind users that they can 
 sponsor my projects if they find them useful. It also allows attribution on the dev machine of a sponsorship 
 to potentially unlock additional functionality (or just remove the reminder and thank instead!). SponsorLink 
-never issues any messages outside of IDE usage, so it will never disrupt your CI/CD workflows or CLI builds.
+never issues any messages outside of IDE or interactive CLI usage, so it will never disrupt your CI/CD workflows or 
+CLI builds.
 
 If you arrived here from an IDE and are interested in sponsoring, the (one-time) steps are:
 

--- a/sponsorlinkr.md
+++ b/sponsorlinkr.md
@@ -1,2 +1,2 @@
 *This project uses [SponsorLink](https://github.com/devlooped#sponsorlink) to attribute sponsor status (direct, indirect or implicit).*
-*For IDE usage, sponsor status is required. IDE-only warnings will be issued after a grace period otherwise.*
+*For IDE usage (without warnings), sponsor status is required. IDE-only warnings will be issued after a grace period otherwise.*

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+<Project TreatAsLocalProperty="VersionPrefix">
   <!-- To extend/change the defaults, create a Directory.props alongside this file -->
 
   <PropertyGroup Label="CI" Condition="'$(CI)' == ''">
@@ -20,6 +20,7 @@
 
   <PropertyGroup Label="NuGet">
     <Authors>Daniel Cazzulino</Authors>
+    <Company>Devlooped</Company>
     <Copyright>Copyright (C) Daniel Cazzulino and Contributors. All rights reserved.</Copyright>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -42,6 +43,10 @@
 
     <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
     <GeneratePathProperty>true</GeneratePathProperty>
+    <!-- Avoid warnings for test projects when we run dotnet pack on the whole solution. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <!-- See https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#prunepackagereference-specification -->
+    <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -126,11 +131,22 @@
     <_VersionLabel>$(_VersionLabel.Replace('/merge', ''))</_VersionLabel>
     <!-- Finally sanitize the branch with dashes, so we can build path-separated branches, like rel/v1.0.0 or feature/foo -->
     <_VersionLabel>$(_VersionLabel.Replace('/', '-'))</_VersionLabel>
+    <!-- And underscores which are also invalid labels, so we can use branches like dev/feature_foo -->
+    <_VersionLabel>$(_VersionLabel.Replace('_', '-'))</_VersionLabel>
 
     <!-- Set sanitized version to the actual version suffix used in build/pack -->
     <VersionSuffix Condition="!$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</VersionSuffix>
     <!-- Special case for tags, the label is actually the version. Backs compat since passed-in value overrides MSBuild-set one -->
     <Version Condition="$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</Version>
+
+    <!-- In order for latest from main/master to always be greatest when using -prerelease switch on install/run, 
+         we change the scheme as follows:
+         - main/master remain as today: VersionPrefix: 42.42.${{ github.run_number }}  (from yaml)
+         - others: VersionPrefix: 42.42.0-[label].${{ github.run_number }}
+    -->
+    <IsMaster Condition="$(VersionLabel.Contains('refs/heads/main')) or $(VersionLabel.Contains('refs/heads/master'))">true</IsMaster>
+    <VersionPrefix Condition="'$(IsMaster)' != 'true'">42.42.0</VersionPrefix>
+    <VersionSuffix Condition="'$(IsMaster)' != 'true'">$(VersionSuffix).$(GITHUB_RUN_NUMBER)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">
@@ -148,6 +164,10 @@
     <Using Include="System.ArgumentException" Static="true" />
     <Using Include="System.ArgumentOutOfRangeException" Static="true" />
     <Using Include="System.ArgumentNullException" Static="true" />
+  </ItemGroup>
+
+  <ItemGroup Label="OSMF" Condition="Exists('$(MSBuildThisFileDirectory)..\osmfeula.txt')">
+    <Content Include="$(MSBuildThisFileDirectory)..\osmfeula.txt" Link="osmfeula.txt" Pack="true" PackagePath="OSMFEULA.txt" />
   </ItemGroup>
 
   <Import Project="Directory.props" Condition="Exists('Directory.props')"/>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -165,21 +165,34 @@
 
     <PropertyGroup>
       <RepositoryRoot>@(_GitSourceRoot)</RepositoryRoot>
+      <!-- Only change if it wasn't just the default from Microsoft.NET.DefaultAssemblyInfo.targets -->
+      <ProductFromUrl Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">$([System.IO.Path]::GetFileNameWithoutExtension($(PrivateRepositoryUrl)))</ProductFromUrl>
+      <Product Condition="'$(Product)' == '$(AssemblyName)' and '$(ProductFromUrl)' != ''">$(ProductFromUrl)</Product>
     </PropertyGroup>
 
   </Target>
 
   <Target Name="UpdatePackageMetadata"
           BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GetAssemblyVersion;GetPackageMetadata;GenerateNuspec;Pack"
-          DependsOnTargets="EnsureProjectInformation"
+          DependsOnTargets="EnsureProjectInformation;UpdatePackageLicense"
           Condition="'$(SourceControlInformationFeatureSupported)' == 'true' And
                      '$(IsPackable)' == 'true'">
     <PropertyGroup>
-      <PackageProjectUrl Condition="'$(PackageProjectUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(RepositoryUrl)</PackageProjectUrl>
+      <PackageProjectUrl Condition="'$(PackageProjectUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(RepositoryUrl.Replace('.git', ''))</PackageProjectUrl>
       <PackageDescription>$(Description)</PackageDescription>
-      <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl)/blob/main/changelog.md</PackageReleaseNotes>
+      <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl.Replace('.git', ''))/blob/main/changelog.md</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
+
+  <Target Name="UpdatePackageLicense">
+    <!-- If project has a None/Content item with PackagePath=OSMFEULA.txt -->
+    <PropertyGroup Condition="@(None -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != '' or @(Content -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != ''">
+      <PackageLicenseExpression></PackageLicenseExpression>
+      <PackageLicenseFile>OSMFEULA.txt</PackageLicenseFile>
+      <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    </PropertyGroup>
+  </Target>
+
 
   <!-- Import before UsingTask because first to declare tasks wins -->
   <Import Project="Directory.targets" Condition="Exists('Directory.targets')"/>


### PR DESCRIPTION
# devlooped/oss

- Enhance documentation instructions for project work https://github.com/devlooped/oss/commit/e616d89
- Use GH_TOKEN if available for PR https://github.com/devlooped/oss/commit/77e83f2
- Upgrade create-pull-request action to version 8 https://github.com/devlooped/oss/commit/d00364f
- Update dotnet-file sync command with init option https://github.com/devlooped/oss/commit/f279ae9
- Set GCM creds to GIT cache https://github.com/devlooped/oss/commit/41fcf7b
- Cap rate limit wait at 5 minutes, abort if longer https://github.com/devlooped/oss/commit/61a602f
- Enhance include workflow with OSMF EULA support https://github.com/devlooped/oss/commit/f2050db
- Trim whitespace in file content replacement https://github.com/devlooped/oss/commit/e53557f
- Fix path pattern for markdown files in workflow https://github.com/devlooped/oss/commit/6a6de05
- Fix error message quotes in includes.yml https://github.com/devlooped/oss/commit/26e8cb7
- Set severity of IDE1100 to none https://github.com/devlooped/oss/commit/1ed9afe
- Set explicit tab size and eol for code files https://github.com/devlooped/oss/commit/5dba0d0
- Revert EOL change in editorconfig for C# files https://github.com/devlooped/oss/commit/2d0e5a5
- Change label from 'docs' to 'dependencies' https://github.com/devlooped/oss/commit/2d1fb4e
- Revert indent size for project files https://github.com/devlooped/oss/commit/a62c459
- Avoid failure on PR creation if osmfeula.txt doesn't exist in repo https://github.com/devlooped/oss/commit/8ff5178
- Update create-pull-request action to version 8 https://github.com/devlooped/oss/commit/0662872
- Group Spectre.Console updates https://github.com/devlooped/oss/commit/917ff54
- Group MEAI packages together https://github.com/devlooped/oss/commit/e733294
- Move dotnet setup to composite action https://github.com/devlooped/oss/commit/08c7077
- Ensure lf for Scriban templates always https://github.com/devlooped/oss/commit/4a9aa32
- Switch to dotnet-env for .NET SDK setup https://github.com/devlooped/oss/commit/56c2b85
- Switch to dnx retest shorthand https://github.com/devlooped/oss/commit/fddfd89
- Ensure quiet confirmation of tool download/install https://github.com/devlooped/oss/commit/e11b002
- Ensure dnx run succeeds even on Windows https://github.com/devlooped/oss/commit/7f5f9ee
- Update branches for push event in build.yml https://github.com/devlooped/oss/commit/5da103c
- Publish builds should point to nuget.org not CI feed https://github.com/devlooped/oss/commit/db918f0
- Ignore .env files recursively https://github.com/devlooped/oss/commit/3776526
- Ignore *.local recursively https://github.com/devlooped/oss/commit/a225b7a
- Ignore slnx file format too https://github.com/devlooped/oss/commit/68b409c
- Update Directory.Build.props with support for underscores in branch name https://github.com/devlooped/oss/commit/81d972f
- Add Company MSBuild property by default https://github.com/devlooped/oss/commit/c509be4
- Disable warnings for non-packable test projects https://github.com/devlooped/oss/commit/95b338b
- Update versioning scheme in Directory.Build.props https://github.com/devlooped/oss/commit/f2400ef
- Enable package pruning in Directory.Build.props https://github.com/devlooped/oss/commit/0ff8b7b
- If the OSMF eula is present, switch to its license file https://github.com/devlooped/oss/commit/4b84c54
- Change file type from None to Content for osmfeula.txt https://github.com/devlooped/oss/commit/fd03672
- Add Pack attribute to OSMFEULA content item https://github.com/devlooped/oss/commit/dd13ed3
- Improve default Product metadata, remove .git from user-facing URLs https://github.com/devlooped/oss/commit/4339749
- Consider either None or Content for OSMF license patching https://github.com/devlooped/oss/commit/083a37b

# devlooped/.github

- Update wording for Maintenance Fee sponsorship details https://github.com/devlooped/.github/commit/e37fbcc
- Add reusable OSMF EULA template https://github.com/devlooped/.github/commit/666a2a7
- Update readme.md clarifying lib usage https://github.com/devlooped/.github/commit/0a541f1
- Update readme.md https://github.com/devlooped/.github/commit/65c1a68
- Update profile with OSMF note https://github.com/devlooped/.github/commit/181f02c
- Clarify that it's for warning-free usage https://github.com/devlooped/.github/commit/233691f
- Add short link to profile #osmf https://github.com/devlooped/.github/commit/33c69a3
- Revise readme for organization account https://github.com/devlooped/.github/commit/1bb356f
- Revise wording and update GitHub stats titles https://github.com/devlooped/.github/commit/1d31ded
- Simplify Code of Conduct document https://github.com/devlooped/.github/commit/5f8692d